### PR TITLE
added mariadb config

### DIFF
--- a/charts/mariadb/values.yaml
+++ b/charts/mariadb/values.yaml
@@ -15,13 +15,40 @@ mariadb:
   primary:
     configuration: |-
       [mysqld]
+      skip-name-resolve
+      explicit_defaults_for_timestamp
+      basedir=/opt/bitnami/mariadb
+      plugin_dir=/opt/bitnami/mariadb/plugin
+      port=3306
+      socket=/opt/bitnami/mariadb/tmp/mysql.sock
+      tmpdir=/opt/bitnami/mariadb/tmp
+      max_allowed_packet=16M
+      bind-address=*
+      pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid
+      log-error=/opt/bitnami/mariadb/logs/mysqld.log
+      slow_query_log=0
+      slow_query_log_file=/opt/bitnami/mariadb/logs/mysqld.log
+      long_query_time=10.0
       innodb_page_size=32k
-      character-set-server=UTF8
-      collation-server=utf8_general_ci
+      character-set-server=utf8mb4
+      collation-server=utf8mb4_unicode_520_ci
 
       [client]
-      default-character-set=UTF8
+      port=3306
+      socket=/opt/bitnami/mariadb/tmp/mysql.sock
+      default-character-set=utf8mb4
+      plugin_dir=/opt/bitnami/mariadb/plugin
+
+      [manager]
+      port=3306
+      socket=/opt/bitnami/mariadb/tmp/mysql.sock
+      pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid
+
+      [mysql]
+      default-character-set=utf8mb4
     
+    existingConfigmap: ""
+
     podSecurityContext:
       enabled: false
     containerSecurityContext:

--- a/charts/mariadb/values.yaml
+++ b/charts/mariadb/values.yaml
@@ -13,6 +13,15 @@ mariadb:
       GRANT ALL PRIVILEGES ON *.* TO 'callweb'@'%';
 
   primary:
+    configuration: |-
+      [mysqld]
+      innodb_page_size=32k
+      character-set-server=UTF8
+      collation-server=utf8_general_ci
+
+      [client]
+      default-character-set=UTF8
+    
     podSecurityContext:
       enabled: false
     containerSecurityContext:


### PR DESCRIPTION
The current ARDA survey requires an increase in the row size (row size is half of the page size). Also noticed that mariadb's default character set is latin1 which doesn't support BC Sans.